### PR TITLE
EPMRPP-112982 | Adding chart-release.yml workflow

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -1,0 +1,33 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/**'
+      - '.github/workflows/chart-release.yml'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup git credentials
+        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          name: 'reportportal.io'
+          email: 'support@reportportal.io'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release Helm Chart
+        uses: helm/chart-releaser-action@v1
+        with:
+          charts_dir: charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Automates Helm chart release on merge to master using helm/chart-releaser-action.
Removes dependency on manual release workflow and aligns behavior with ReportPortal Kubernetes.
Charts are packaged from /charts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated Helm chart releases triggered on master branch updates when chart directory contents or release configuration changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->